### PR TITLE
Prevent excessive messages

### DIFF
--- a/server/messages/common/issues.js
+++ b/server/messages/common/issues.js
@@ -1,5 +1,15 @@
-var format = require( 'util' ).format;
+var format = require( 'util' ).format,
+    constants = require( '../../../shared/constants/' );
 
 module.exports = function( body ) {
+    var timeSinceCreated;
+
+    if ( 'opened' !== body.action ) {
+        timeSinceCreated = Date.now() - Date.parse( body.issue.created_at );
+        if ( timeSinceCreated < constants.app.ISSUE_IGNORE_CREATED_WITHIN_MS ) {
+            return;
+        }
+    }
+
     return format( '[%s] Issue %s by %s - #%d: %s', body.repository.full_name, body.action, body.sender.login, body.issue.number, body.issue.title );
 };

--- a/server/messages/common/pull-request.js
+++ b/server/messages/common/pull-request.js
@@ -1,5 +1,15 @@
-var format = require( 'util' ).format;
+var format = require( 'util' ).format,
+    constants = require( '../../../shared/constants/' );
 
 module.exports = function( body ) {
+    var timeSinceCreated;
+
+    if ( 'opened' !== body.action ) {
+        timeSinceCreated = Date.now() - Date.parse( body.pull_request.created_at );
+        if ( timeSinceCreated < constants.app.ISSUE_IGNORE_CREATED_WITHIN_MS ) {
+            return;
+        }
+    }
+
     return format( '[%s] Pull request %s by %s - #%d: %s', body.repository.full_name, body.action, body.sender.login, body.pull_request.number, body.pull_request.title );
 };

--- a/server/messages/slack/issues.js
+++ b/server/messages/slack/issues.js
@@ -2,7 +2,16 @@ var format = require( 'util' ).format,
     constants = require( '../../../shared/constants/' );
 
 module.exports = function( body ) {
-    var message = {
+    var timeSinceCreated, message;
+
+    if ( 'opened' !== body.action ) {
+        timeSinceCreated = Date.now() - Date.parse( body.issue.created_at );
+        if ( timeSinceCreated < constants.app.ISSUE_IGNORE_CREATED_WITHIN_MS ) {
+            return;
+        }
+    }
+
+    message = {
         fallback: format( '[%s] Issue %s by %s - #%d: %s', body.repository.full_name, body.action, body.sender.login, body.issue.number, body.issue.title ),
         pretext: format( '[%s] Issue %s by %s', body.repository.full_name, body.action, body.sender.login ),
         title: format( '#%d: %s', body.issue.number, body.issue.title ),

--- a/server/messages/slack/pull-request.js
+++ b/server/messages/slack/pull-request.js
@@ -2,6 +2,15 @@ var format = require( 'util' ).format,
     constants = require( '../../../shared/constants/' );
 
 module.exports = function( body ) {
+    var timeSinceCreated;
+
+    if ( 'opened' !== body.action ) {
+        timeSinceCreated = Date.now() - Date.parse( body.pull_request.created_at );
+        if ( timeSinceCreated < constants.app.ISSUE_IGNORE_CREATED_WITHIN_MS ) {
+            return;
+        }
+    }
+
     return {
         fallback: format( '[%s] Pull request %s by %s - #%d: %s', body.repository.full_name, body.action, body.sender.login, body.pull_request.number, body.pull_request.title ),
         pretext: format( '[%s] Pull request %s by %s', body.repository.full_name, body.action, body.sender.login ),

--- a/shared/constants/app.js
+++ b/shared/constants/app.js
@@ -5,5 +5,6 @@ module.exports = {
     NAME: 'Ghat',
     GITHUB_REPO_URL: 'https://github.com/aduth/ghat',
     COLOR_PRIMARY: '#333447',
-    COLOR_SECONDARY: '#e56a74'
+    COLOR_SECONDARY: '#e56a74',
+    ISSUE_IGNORE_CREATED_WITHIN_MS: 30000
 };

--- a/test/specs/server/messages/common/issues.js
+++ b/test/specs/server/messages/common/issues.js
@@ -3,6 +3,27 @@ var expect = require( 'chai' ).expect,
     generateMessage = require( '../../../../../server/messages/common/issues' );
 
 describe( 'issues', function() {
+    it( 'should not generate a message if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.issue.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.be.undefined;
+    } );
+
+    it( 'should generate a message for opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.action = 'opened';
+        copy.issue.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.not.be.undefined;
+    } );
+
     it( 'should generate the expected message', function() {
         var message = generateMessage( payload );
 

--- a/test/specs/server/messages/common/pull-request.js
+++ b/test/specs/server/messages/common/pull-request.js
@@ -3,6 +3,27 @@ var expect = require( 'chai' ).expect,
     generateMessage = require( '../../../../../server/messages/common/pull-request' );
 
 describe( 'pull-request', function() {
+    it( 'should not generate a message for non-opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.action = 'assigned';
+        copy.pull_request.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.be.undefined;
+    } );
+
+    it( 'should generate a message for opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.pull_request.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.not.be.undefined;
+    } );
+
     it( 'should generate the expected message', function() {
         var message = generateMessage( payload );
 

--- a/test/specs/server/messages/slack/issues.js
+++ b/test/specs/server/messages/slack/issues.js
@@ -3,6 +3,27 @@ var expect = require( 'chai' ).expect,
     generateMessage = require( '../../../../../server/messages/slack/issues' );
 
 describe( 'issues', function() {
+    it( 'should not generate a message for non-opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.issue.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.be.undefined;
+    } );
+
+    it( 'should generate a message for opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.action = 'opened';
+        copy.issue.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.not.be.undefined;
+    } );
+
     it( 'should generate the expected message', function() {
         var message = generateMessage( payload );
 

--- a/test/specs/server/messages/slack/pull-request.js
+++ b/test/specs/server/messages/slack/pull-request.js
@@ -3,6 +3,27 @@ var expect = require( 'chai' ).expect,
     generateMessage = require( '../../../../../server/messages/slack/pull-request' );
 
 describe( 'pull-request', function() {
+    it( 'should not generate a message for non-opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.action = 'assigned';
+        copy.pull_request.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.be.undefined;
+    } );
+
+    it( 'should generate a message for opened action if newly created', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.pull_request.created_at = new Date();
+        message = generateMessage( copy );
+
+        expect( message ).to.not.be.undefined;
+    } );
+
     it( 'should generate the expected message', function() {
         var message = generateMessage( payload );
 


### PR DESCRIPTION
Fixes #3 

This pull request seeks to avoid excessive messages being generated for "issues" or "pull-request" webhook actions if recently opened.
