### PR TITLE
Use react-select as searchable dropdown

### DIFF
--- a/assets/less/app.less
+++ b/assets/less/app.less
@@ -1,6 +1,7 @@
 // Vendor
 @import (less) "../components/normalize.css/normalize.css";
 @import (less) "../components/github-fork-ribbon-css/gh-fork-ribbon.css";
+@import "../../node_modules/react-select/less/select";
 
 // Mixins
 @import "mixins/font-face";

--- a/assets/less/components/connection.less
+++ b/assets/less/components/connection.less
@@ -22,7 +22,7 @@
     margin: 14px 0;
 }
 
-.connection.github .select {
+.connection.github .Select {
     display: none;
 }
 
@@ -33,7 +33,7 @@
     bottom: 30px;
 }
 
-.connection__actions .select__input {
+.connection__actions .Select {
     margin: 4px 0;
 }
 

--- a/assets/less/components/select.less
+++ b/assets/less/components/select.less
@@ -1,31 +1,9 @@
-.select {
-    position: relative;
+.Select {
     max-width: 400px;
+    font-size: 14px;
+    text-align: left;
 }
 
-.select__expand {
-    position: absolute;
-    right: 14px;
-    top: 50%;
-    margin-top: -12px;
-    font-size: 24px;
-    line-height: 1;
-    pointer-events: none;
-}
-
-.select__input {
-    -webkit-appearance: none;
-    width: 100%;
-    padding: 6px 36px 6px 14px;
+.Select-control {
     cursor: pointer;
-    background: #fff;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-shadow: 0 2px 0 0 rgba( 0, 0, 0, 0.1 );
-    font-size: @text-size * 0.9;
-
-    &:disabled {
-        background-color: #f7f7f7;
-        cursor: not-allowed;
-    }
 }

--- a/client/components/configure-contact.jsx
+++ b/client/components/configure-contact.jsx
@@ -35,7 +35,11 @@ module.exports = React.createClass({
                 </p>
                 <label className="form-option">
                     <span className="form-option__label">Choose a contact:</span>
-                    <Select value={ this.props.value } onChange={ this.props.onValueChanged } options={ this.getOptions() } />
+                    <Select
+                        value={ this.props.value }
+                        onChange={ this.props.onValueChanged }
+                        options={ this.getOptions() }
+                        searchable={ true } />
                 </label>
             </li>
         );

--- a/client/components/configure-filter.jsx
+++ b/client/components/configure-filter.jsx
@@ -109,7 +109,7 @@ module.exports = React.createClass({
             <tr className="configure-filter">
                 <td width="40%">{ this.getFieldInput() }</td>
                 <td width="20%">
-                    <Select options={ this.getOperatorOptions() } includeDefault={ false } disabled={ ! this.props.value.field } value={ this.props.value.operator } onChange={ this.onChange.bind( this, 'operator' ) } />
+                    <Select options={ this.getOperatorOptions() } placeholder={ false } disabled={ ! this.props.value.field } value={ this.props.value.operator } onChange={ this.onChange.bind( this, 'operator' ) } />
                 </td>
                 <td width="35%">{ this.getValueInput() }</td>
                 <td width="15%">

--- a/client/components/configure-repository.jsx
+++ b/client/components/configure-repository.jsx
@@ -33,7 +33,11 @@ module.exports = React.createClass({
                 </p>
                 <label className="form-option">
                     <span className="form-option__label">Choose a repository:</span>
-                    <Select value={ this.props.value } onChange={ this.props.onValueChanged } options={ this.getOptions() } />
+                    <Select
+                        value={ this.props.value }
+                        onChange={ this.props.onValueChanged }
+                        options={ this.getOptions() }
+                        searchable={ true } />
                 </label>
             </li>
         );

--- a/client/components/connection.jsx
+++ b/client/components/connection.jsx
@@ -80,7 +80,7 @@ module.exports = React.createClass({
             return { value: provider, label: integrations[ provider ].name };
         });
 
-        return <Select options={ options } value={ this.getSelectedProvider() } onChange={ this.onProviderChange } includeDefault={ 'Choose a service' } />;
+        return <Select options={ options } value={ this.getSelectedProvider() } onChange={ this.onProviderChange } placeholder={ 'Choose a service' } />;
     },
 
     getManualEntryButtonElement: function() {

--- a/client/components/select.jsx
+++ b/client/components/select.jsx
@@ -1,4 +1,6 @@
-var React = require( 'react' );
+var React = require( 'react' ),
+    Select = require( 'react-select' ),
+    omit = require( 'lodash/object/omit' );
 
 module.exports = React.createClass({
     displayName: 'Select',
@@ -6,63 +8,46 @@ module.exports = React.createClass({
     propTypes: {
         value: React.PropTypes.oneOfType([ React.PropTypes.string, React.PropTypes.number ]),
         onChange: React.PropTypes.func,
-        includeDefault: React.PropTypes.oneOfType([ React.PropTypes.bool, React.PropTypes.string ]),
-        options: React.PropTypes.array,
-        disabled: React.PropTypes.bool
+        options: React.PropTypes.oneOfType([
+            React.PropTypes.arrayOf( React.PropTypes.shape({
+                value: React.PropTypes.string,
+                label: React.PropTypes.string
+            }) ),
+            React.PropTypes.arrayOf( React.PropTypes.string )
+        ]),
+        searchable: React.PropTypes.bool,
+        clearable: React.PropTypes.bool,
+        disabled: React.PropTypes.bool,
+        placeholder: React.PropTypes.string
     },
 
     getDefaultProps: function() {
         return {
             onChange: function() {},
-            includeDefault: true,
             options: Object.freeze([]),
-            disabled: false
+            searchable: false,
+            clearable: false,
+            disabled: false,
+            placeholder: ''
         };
     },
 
-    getOptionValue: function( option ) {
-        return 'object' === typeof option ? option.value : option;
-    },
-
     getOptions: function() {
-        var options = this.props.options,
-            defaultLabel;
-
-        // Include a default option unless explicitly disabled via a false
-        // value. A true value will default the label to an empty string,
-        // otherwise the string prop will be used.
-        if ( false !== this.props.includeDefault ) {
-            defaultLabel = true === this.props.includeDefault ? '' : this.props.includeDefault;
-            options = [{ value: '', label: defaultLabel }].concat( options );
-        }
-
-        return options;
-    },
-
-    getOptionElements: function() {
-        return this.getOptions().map(function( option ) {
-            if ( 'object' === typeof option ) {
-                return <option key={ option.value + option.label } value={ option.value }>{ option.label }</option>;
+        return this.props.options.map(function( option ) {
+            if ( 'string' === typeof option ) {
+                return {
+                    value: option,
+                    label: option
+                };
             } else {
-                return <option key={ option } value={ option }>{ option }</option>;
+                return option;
             }
         });
     },
 
-    onSelectedValueChanged: function( domEvent ) {
-        this.props.onChange( domEvent.target.value );
-    },
-
     render: function() {
-        var value = this.props.value || this.getOptionValue( this.getOptions()[0] );
+        var transferredProps = omit( this.props, 'options' );
 
-        return (
-            <div className="select">
-                <select className="select__input" value={ value } onChange={ this.onSelectedValueChanged } disabled={ this.props.disabled }>
-                    { this.getOptionElements() }
-                </select>
-                <span className="fa fa-caret-down select__expand" />
-            </div>
-        );
+        return <Select options={ this.getOptions() } { ...transferredProps } />;
     }
 });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "mongoose": "^3.8.21",
     "oauth": "^0.9.12",
     "react": "^0.12.1",
+    "react-select": "^0.4.7",
     "reactify": "^0.17.1",
     "serve-static": "^1.7.1",
     "shortid": "^2.1.3",


### PR DESCRIPTION
Fixes #6 

This pull request adds `react-select` as a searchable dropdown field to facilitate searching of large lists (repositories, contacts).
