### PR TITLE
Only include body in opened action

### DIFF
--- a/server/messages/slack/issues.js
+++ b/server/messages/slack/issues.js
@@ -4,6 +4,7 @@ var format = require( 'util' ).format,
 module.exports = function( body ) {
     var timeSinceCreated, message;
 
+    // Prevent excessive messaging for new issues
     if ( 'opened' !== body.action ) {
         timeSinceCreated = Date.now() - Date.parse( body.issue.created_at );
         if ( timeSinceCreated < constants.app.ISSUE_IGNORE_CREATED_WITHIN_MS ) {
@@ -11,15 +12,21 @@ module.exports = function( body ) {
         }
     }
 
+    // Generate message
     message = {
         fallback: format( '[%s] Issue %s by %s - #%d: %s', body.repository.full_name, body.action, body.sender.login, body.issue.number, body.issue.title ),
         pretext: format( '[%s] Issue %s by %s', body.repository.full_name, body.action, body.sender.login ),
         title: format( '#%d: %s', body.issue.number, body.issue.title ),
         title_link: body.issue.html_url,
-        text: body.issue.body,
         color: constants.app.COLOR_SECONDARY
     };
 
+    // Only include body of the issue when first created
+    if ( 'opened' === body.action ) {
+        message.text = body.issue.body;
+    }
+
+    // Assign fields for actions with additional information
     switch ( body.action ) {
         case 'labeled':
         case 'unlabeled':

--- a/server/messages/slack/pull-request.js
+++ b/server/messages/slack/pull-request.js
@@ -2,8 +2,9 @@ var format = require( 'util' ).format,
     constants = require( '../../../shared/constants/' );
 
 module.exports = function( body ) {
-    var timeSinceCreated;
+    var timeSinceCreated, message;
 
+    // Prevent excessive messaging for new pull requests
     if ( 'opened' !== body.action ) {
         timeSinceCreated = Date.now() - Date.parse( body.pull_request.created_at );
         if ( timeSinceCreated < constants.app.ISSUE_IGNORE_CREATED_WITHIN_MS ) {
@@ -11,12 +12,19 @@ module.exports = function( body ) {
         }
     }
 
-    return {
+    // Generate message
+    message = {
         fallback: format( '[%s] Pull request %s by %s - #%d: %s', body.repository.full_name, body.action, body.sender.login, body.pull_request.number, body.pull_request.title ),
         pretext: format( '[%s] Pull request %s by %s', body.repository.full_name, body.action, body.sender.login ),
         title: format( '#%d: %s', body.pull_request.number, body.pull_request.title ),
         title_link: body.pull_request.html_url,
-        text: body.pull_request.body,
         color: constants.app.COLOR_SECONDARY
     };
+
+    // Only include body of the pull request when first created
+    if ( 'opened' === body.action ) {
+        message.text = body.pull_request.body;
+    }
+
+    return message;
 };

--- a/test/specs/server/messages/slack/issues.js
+++ b/test/specs/server/messages/slack/issues.js
@@ -31,12 +31,22 @@ describe( 'issues', function() {
         expect( message.pretext ).to.equal( '[baxterthehacker/public-repo] Issue labeled by baxterthehacker' );
         expect( message.title ).to.equal( '#51: Spelling error in the README file' );
         expect( message.title_link ).to.equal( 'https://github.com/baxterthehacker/public-repo/issues/51' );
-        expect( message.text ).to.equal( 'It looks like you accidently spelled \'commit\' with two \'t\'s.' );
+        expect( message.text ).to.be.empty;
         expect( message.fields ).to.eql([{
             title: 'Label added',
             value: 'bug',
             short: true
         }]);
+    });
+
+    it( 'should include the text for opened action only', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.action = 'opened';
+        message = generateMessage( copy );
+
+        expect( message.text ).to.be.equal( 'It looks like you accidently spelled \'commit\' with two \'t\'s.' );
     });
 
     it( 'should omit fields if not assigned or labeled', function() {
@@ -61,7 +71,7 @@ describe( 'issues', function() {
         expect( message.pretext ).to.equal( '[baxterthehacker/public-repo] Issue assigned by baxterthehacker' );
         expect( message.title ).to.equal( '#51: Spelling error in the README file' );
         expect( message.title_link ).to.equal( 'https://github.com/baxterthehacker/public-repo/issues/51' );
-        expect( message.text ).to.equal( 'It looks like you accidently spelled \'commit\' with two \'t\'s.' );
+        expect( message.text ).to.be.empty;
         expect( message.fields ).to.eql([{
             title: 'User assigned',
             value: 'aduth',

--- a/test/specs/server/messages/slack/pull-request.js
+++ b/test/specs/server/messages/slack/pull-request.js
@@ -31,6 +31,16 @@ describe( 'pull-request', function() {
         expect( message.pretext ).to.equal( '[baxterthehacker/public-repo] Pull request opened by baxterthehacker' );
         expect( message.title ).to.equal( '#50: Update the README with new information' );
         expect( message.title_link ).to.equal( 'https://github.com/baxterthehacker/public-repo/pull/50' );
-        expect( message.text ).to.equal( 'This is a pretty simple change that we need to pull into master.' );
+        expect( message.text ).to.be.equal( 'This is a pretty simple change that we need to pull into master.' );
+    });
+
+    it( 'should include the text for opened action only', function() {
+        var copy = JSON.parse( JSON.stringify( payload ) ),
+            message;
+
+        copy.action = 'assigned';
+        message = generateMessage( copy );
+
+        expect( message.text ).to.be.empty;
     });
 });


### PR DESCRIPTION
Fixes #14 

This pull request only includes the body of an issue or pull request if the `action` is equal to `opened`.
